### PR TITLE
Add font size as a param for the generator

### DIFF
--- a/lib/avatar_magick/generators/initial_avatar.rb
+++ b/lib/avatar_magick/generators/initial_avatar.rb
@@ -17,6 +17,7 @@ module AvatarMagick
         color       = opts[:color] ? "##{opts[:color]}" : content.env[:avatar_magick][:color]
         size        = opts[:size] || content.env[:avatar_magick][:size]
         font        = opts[:font] || content.env[:avatar_magick][:font]
+        font_size   = opts[:font_size]
 
         # extract the first letter of the first 3 words and capitalize
         text = (string.split(/\s/)- ["", nil]).map { |t| t[0].upcase }.slice(0, 3).join('')
@@ -24,7 +25,7 @@ module AvatarMagick
         w, h = size.split('x').map { |d| d.to_i }
         h ||= w
 
-        font_size = ( w / [text.length, 2].max ).to_i
+        font_size = ( w / [text.length, 2].max ).to_i unless font_size.present?
 
         # Settings
         args.push("-gravity none")

--- a/lib/avatar_magick/plugin.rb
+++ b/lib/avatar_magick/plugin.rb
@@ -12,6 +12,7 @@ module AvatarMagick
       app.env[:avatar_magick][:background_color]  = opts[:background_color] ? "##{opts[:background_color]}" : "#000000"
       app.env[:avatar_magick][:size]              = opts[:size] || "120x120"
       app.env[:avatar_magick][:font]              = opts[:font] || "Arial-Regular"
+      app.env[:avatar_magick][:font_size]         = opts[:font_size]
 
       app.add_generator :initial_avatar, AvatarMagick::Generators::InitialAvatar.new
     end


### PR DESCRIPTION
Adds a simple way to force the font size of an avatar before generating it. By default the font size is the same as before.